### PR TITLE
Update BizzaAIOFighter plugin name

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bizzaaiofighter/BizzaAIOFighterInfoOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bizzaaiofighter/BizzaAIOFighterInfoOverlay.java
@@ -26,7 +26,7 @@ public class BizzaAIOFighterInfoOverlay extends OverlayPanel {
         try {
             panelComponent.setPreferredSize(new Dimension(250, 400));
             panelComponent.getChildren().add(TitleComponent.builder()
-                    .text("\uD83E\uDD86 AIO Fighter \uD83E\uDD86")
+                    .text("\uD83E\uDD86 Bizza AIO Fighter \uD83E\uDD86")
                     .color(Color.ORANGE)
                     .build());
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bizzaaiofighter/BizzaAIOFighterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bizzaaiofighter/BizzaAIOFighterPlugin.java
@@ -47,7 +47,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 @PluginDescriptor(
-        name = PluginDescriptor.Mocrosoft + "AIO Fighter",
+        name = PluginDescriptor.Mocrosoft + "Bizza AIO Fighter",
         description = "Microbot Fighter plugin",
         tags = {"fight", "microbot", "misc", "combat", "playerassistant"},
         enabledByDefault = false


### PR DESCRIPTION
## Summary
- rename the Bizza AIO Fighter plugin to a unique name
- update info overlay heading to match

## Testing
- `mvn -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c0804b848330bb7257724852c615