### PR TITLE
Add banking deposit mode selection

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bizzaaiofighter/BizzaAIOFighterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bizzaaiofighter/BizzaAIOFighterConfig.java
@@ -7,6 +7,7 @@ import net.runelite.client.plugins.microbot.bizzaaiofighter.enums.PlayStyle;
 import net.runelite.client.plugins.microbot.bizzaaiofighter.enums.PrayerStyle;
 import net.runelite.client.plugins.microbot.bizzaaiofighter.enums.HardAttackStyle;
 import net.runelite.client.plugins.microbot.bizzaaiofighter.enums.State;
+import net.runelite.client.plugins.microbot.bizzaaiofighter.enums.DepositMethod;
 import net.runelite.client.plugins.microbot.inventorysetups.InventorySetup;
 import net.runelite.client.plugins.microbot.util.magic.Rs2CombatSpells;
 import net.runelite.client.plugins.microbot.util.slayer.enums.SlayerMaster;
@@ -857,6 +858,17 @@ public interface BizzaAIOFighterConfig extends Config {
     )
     default boolean ignoreTeleport() {
         return true;
+    }
+
+    @ConfigItem(
+            keyName = "depositMethod",
+            name = "Bank deposit mode",
+            description = "How items are deposited when banking",
+            position = 10,
+            section = banking
+    )
+    default DepositMethod depositMethod() {
+        return DepositMethod.KEEP_UPKEEP;
     }
 
     // Safety section

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bizzaaiofighter/bank/BankerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bizzaaiofighter/bank/BankerScript.java
@@ -9,6 +9,7 @@ import net.runelite.client.plugins.microbot.bizzaaiofighter.BizzaAIOFighterConfi
 import net.runelite.client.plugins.microbot.bizzaaiofighter.BizzaAIOFighterPlugin;
 import net.runelite.client.plugins.microbot.bizzaaiofighter.constants.Constants;
 import net.runelite.client.plugins.microbot.bizzaaiofighter.enums.State;
+import net.runelite.client.plugins.microbot.bizzaaiofighter.enums.DepositMethod;
 import net.runelite.client.plugins.microbot.util.Rs2InventorySetup;
 import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
 import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
@@ -153,7 +154,22 @@ public class BankerScript extends Script {
         BizzaAIOFighterPlugin.setState(State.BANKING);
         Rs2Prayer.disableAllPrayers();
         if (Rs2Bank.walkToBankAndUseBank()) {
-            depositAllExcept(config);
+            switch (config.depositMethod()) {
+                case DEPOSIT_ALL:
+                    Rs2Bank.depositAll();
+                    break;
+                case RANDOM:
+                    if (new Random().nextBoolean()) {
+                        Rs2Bank.depositAll();
+                    } else {
+                        depositAllExcept(config);
+                    }
+                    break;
+                case KEEP_UPKEEP:
+                default:
+                    depositAllExcept(config);
+                    break;
+            }
             withdrawUpkeepItems(config);
             Rs2Bank.closeBank();
         }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bizzaaiofighter/enums/DepositMethod.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bizzaaiofighter/enums/DepositMethod.java
@@ -1,0 +1,19 @@
+package net.runelite.client.plugins.microbot.bizzaaiofighter.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DepositMethod {
+    DEPOSIT_ALL("Deposit All"),
+    KEEP_UPKEEP("Keep Upkeep"),
+    RANDOM("Random");
+
+    private final String name;
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}


### PR DESCRIPTION
## Summary
- add `DepositMethod` enum for banking behavior
- allow selecting deposit method via plugin config
- support deposit-all, keep-upkeep, or a random choice in banking logic

## Testing
- `mvn -pl runelite-parent install` *(fails: Non-resolvable import POM)*
- `mvn -q -DskipTests install` in `runelite-client` *(fails: dependency versions missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854c8370ee0833097aa79b9f5fb6ed3