### PR TITLE
Add quest item purchasing logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+This repository uses a multi-branch workflow.
+All changes should be merged into the `dev` branch.
+
+Current focus: Enhance the mQuester addon so it can acquire quest items automatically via the Grand Exchange.
+
+- Do **not** modify the RuneLite API or external plugin APIs.
+- Network dependencies fail during compilation; prioritize logic correctness over building.
+- Add verbose logging to help debug item acquisition logic.


### PR DESCRIPTION
## Summary
- document repo instructions for focusing on mQuester item purchases
- extend `MQuestScript` with functions to gather quest item requirements and buy missing items
- call new logic during quest execution

## Testing
- `mvn` not available, so build could not be run

------
https://chatgpt.com/codex/tasks/task_e_6856b42777b883308b7d90d868b8057e