### PR TITLE
Fix item purchase loop

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/quest/MQuestScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/quest/MQuestScript.java
@@ -306,7 +306,15 @@ public class MQuestScript extends Script {
 
         if (itemsMissing.isEmpty())
         {
+            Microbot.log("All quest items accounted for");
             return true;
+        }
+        else
+        {
+            String missingNames = itemsMissing.stream()
+                    .map(r -> getItemName(r.getId()))
+                    .collect(Collectors.joining(", "));
+            Microbot.log("Missing items: " + missingNames);
         }
 
         for (ItemRequirement req : new ArrayList<>(itemsMissing))
@@ -357,7 +365,7 @@ public class MQuestScript extends Script {
             Rs2GrandExchange.buyItemAbove5Percent(name, req.getQuantity());
         }
 
-        Rs2GrandExchange.collectToBank();
+        Rs2GrandExchange.collectToInventory();
         Microbot.log("Finished buying missing quest items");
         grandExchangeItems.clear();
     }


### PR DESCRIPTION
## Summary
- log missing quest items
- collect GE purchases to inventory instead of the bank

## Testing
- `bash ci/build.sh` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857538c0c6883309500e2fea651bbcb