### PR TITLE
Improve Nate Pie Shell logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,6 @@ These steps let Codex build the project in future prompts without reaching exter
 - Example script: `runelite-client/src/main/java/net/runelite/client/plugins/microbot/example`
 
 The `docs/development.md` file contains additional guidance on creating scripts and shows code samples for common tasks.
+
+## Current task
+- `runelite-client/src/main/java/net/runelite/client/plugins/microbot/nateplugins/moneymaking/natepieshells` - Uplifting the plugin to add buying of materials from the Grand Exchange.

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/nateplugins/moneymaking/natepieshells/PieOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/nateplugins/moneymaking/natepieshells/PieOverlay.java
@@ -18,10 +18,12 @@ public class PieOverlay extends OverlayPanel {
         super(plugin);
         setPosition(OverlayPosition.TOP_LEFT);
         setNaughty();
+        Microbot.log("PieOverlay initialized");
     }
     @Override
     public Dimension render(Graphics2D graphics) {
         try {
+            Microbot.log("PieOverlay.render() - updating overlay");
             panelComponent.setPreferredSize(new Dimension(275, 700));
             panelComponent.getChildren().add(TitleComponent.builder()
                     .text("Nate's Shell Maker")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/nateplugins/moneymaking/natepieshells/PiePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/nateplugins/moneymaking/natepieshells/PiePlugin.java
@@ -44,14 +44,19 @@ public class PiePlugin extends Plugin {
     @Override
     protected void startUp() throws AWTException {
         PieScript.totalPieShellsMade = 0;
-		Microbot.pauseAllScripts.compareAndSet(true, false);
+        Microbot.status = "Starting Nate Pie Shell Maker";
+        Microbot.log("PiePlugin.startUp() - Initializing plugin");
+        Microbot.pauseAllScripts.compareAndSet(true, false);
         if (overlayManager != null) {
             overlayManager.add(pieOverlay);
         }
+        Microbot.log("PiePlugin.startUp() - Running script");
         pieScript.run(config);
     }
 
     protected void shutDown() {
+        Microbot.status = "Stopped Nate Pie Shell Maker";
+        Microbot.log("PiePlugin.shutDown() - Shutting down plugin");
         pieScript.shutdown();
         overlayManager.remove(pieOverlay);
     }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/nateplugins/moneymaking/natepieshells/PieScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/nateplugins/moneymaking/natepieshells/PieScript.java
@@ -14,19 +14,31 @@ public class PieScript extends Script {
     public static int totalPieShellsMade = 0;
 
     public boolean run(PieConfig config) {
+        Microbot.status = "Starting Nate Pie Shell Maker";
+        Microbot.log("PieScript.run() - Script started");
         mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
             try {
-				if (!super.run()) return;
-				if (!Microbot.isLoggedIn()) return;
+                if (!super.run()) {
+                    Microbot.log("PieScript.run() - super.run() returned false");
+                    return;
+                }
+                if (!Microbot.isLoggedIn()) {
+                    Microbot.log("PieScript.run() - Client not logged in");
+                    return;
+                }
                 if (Rs2Inventory.count("pie dish") > 0 && (Rs2Inventory.count("pastry dough") > 0)) {
+                    Microbot.status = "Combining pie dish with pastry dough";
+                    Microbot.log("PieScript.run() - Combining pie dishes with pastry dough");
                     Rs2Inventory.combine("pie dish", "pastry dough");
                     sleepUntilOnClientThread(() -> Rs2Widget.getWidget(17694734) != null);
                     keyPress('1');
                     sleepUntilOnClientThread(() -> !Rs2Inventory.hasItem("pie dish"),25000);
 
                     totalPieShellsMade += 14;   // rough example, but you get the point
+                    Microbot.log("PieScript.run() - Completed making pie shells. Total so far: " + totalPieShellsMade);
                     return;
                 } else {
+                    Microbot.log("PieScript.run() - Inventory missing items, banking");
                     bank();
                 }
             } catch (Exception ex) {
@@ -37,20 +49,26 @@ public class PieScript extends Script {
     }
 
     private void bank(){
+        Microbot.status = "Banking";
+        Microbot.log("PieScript.bank() - Opening bank");
         Rs2Bank.openBank();
         if(Rs2Bank.isOpen()){
+            Microbot.log("PieScript.bank() - Bank opened");
             Rs2Bank.depositAll();
             if(Rs2Bank.hasItem("pie dish") &&  Rs2Bank.hasItem("pastry dough")) {
+                Microbot.log("PieScript.bank() - Withdrawing materials");
                 Rs2Bank.withdrawX(true, "pie dish", 14);
                 sleepUntilOnClientThread(() -> Rs2Inventory.hasItem("pie dish"));
                 Rs2Bank.withdrawX(true, "pastry dough", 14);
                 sleepUntilOnClientThread(() -> Rs2Inventory.hasItem("pastry dough"));
             } else {
+                Microbot.log("PieScript.bank() - Out of materials");
                 Microbot.getNotifier().notify("Run out of Materials");
                 shutdown();
             }
         }
         Rs2Bank.closeBank();
+        Microbot.log("PieScript.bank() - Closing bank");
         sleepUntilOnClientThread(() -> !Rs2Bank.isOpen());
     }
 }


### PR DESCRIPTION
## Summary
- add log lines throughout Nate Pie Shell maker for easier debugging
- log initialization and rendering in pie overlay
- log plugin lifecycle events
- update AGENTS with task context

## Testing
- `mvn -o -DskipTests package` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_685d1511357c8330908e2a69d97d9759