### PR TITLE
Add GE buy option and debug logging

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/nateplugins/moneymaking/natepieshells/PieConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/nateplugins/moneymaking/natepieshells/PieConfig.java
@@ -2,9 +2,18 @@ package net.runelite.client.plugins.microbot.nateplugins.moneymaking.natepieshel
 
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
-
+import net.runelite.client.config.ConfigItem;
 
 @ConfigGroup("PieMaking")
 public interface PieConfig extends Config {
 
+    @ConfigItem(
+            keyName = "enableGEBuying",
+            name = "Enable GE Buying",
+            description = "Buy materials from the Grand Exchange when running low",
+            position = 0
+    )
+    default boolean enableGEBuying() {
+        return false;
+    }
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/nateplugins/moneymaking/natepieshells/PieOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/nateplugins/moneymaking/natepieshells/PieOverlay.java
@@ -21,6 +21,9 @@ public class PieOverlay extends OverlayPanel {
     }
     @Override
     public Dimension render(Graphics2D graphics) {
+        if (Microbot.isDebug()) {
+            Microbot.log("PieOverlay.render() - updating overlay");
+        }
         try {
             panelComponent.setPreferredSize(new Dimension(275, 700));
             panelComponent.getChildren().add(TitleComponent.builder()


### PR DESCRIPTION
## Summary
- log pie overlay updates only in debug mode
- add GE buy checkbox to pie shell maker config

## Testing
- `mvn -o -DskipTests package`

------
https://chatgpt.com/codex/tasks/task_e_685d2c7d30388330ba29988e58663c34